### PR TITLE
fix(RetainerInformation): fixed name sizes for non-global regions

### DIFF
--- a/src/packet-processors/processors/npcSpawn.ts
+++ b/src/packet-processors/processors/npcSpawn.ts
@@ -76,6 +76,7 @@ export function npcSpawn(reader: BufferReader, constants: ConstantsList, region?
 				return reader.nextUInt32();
 			}),
 	};
+	// todo: changed 5.5, comment for CN/KR
 	if (region === "Global") {
 		return {
 			...commonRegionPart,

--- a/src/packet-processors/processors/playerSpawn.ts
+++ b/src/packet-processors/processors/playerSpawn.ts
@@ -3,6 +3,7 @@ import { PlayerSpawn } from "../../definitions";
 import { ConstantsList, Region } from "../../models";
 
 export function playerSpawn(reader: BufferReader, constants: ConstantsList, region?: Region): PlayerSpawn {
+	// todo: changed 5.5, comment for CN/KR
 	if (region === "Global") {
 		return {
 			title: reader.nextUInt16(),

--- a/src/packet-processors/processors/retainerInformation.ts
+++ b/src/packet-processors/processors/retainerInformation.ts
@@ -1,8 +1,9 @@
 import { BufferReader } from "../../BufferReader";
 import { RetainerInformation } from "../../definitions";
+import { ConstantsList, Region } from "../../models";
 
-export function retainerInformation(reader: BufferReader): RetainerInformation {
-	return {
+export function retainerInformation(reader: BufferReader, constants: ConstantsList, region: Region): RetainerInformation {
+	const commonRegionPart = {
 		unknown0: reader.nextUInt64(),
 		retainerId: reader.nextUInt64(),
 		hireOrder: reader.nextUInt8(),
@@ -17,6 +18,15 @@ export function retainerInformation(reader: BufferReader): RetainerInformation {
 		ventureId: reader.nextUInt32(),
 		ventureComplete: reader.nextUInt32(),
 		unknown14: reader.nextUInt8(),
-		name: reader.nextString(20),
+	};
+	if (region === "Global") {
+		return {
+			...commonRegionPart,
+			name: reader.nextString(20),
+		};
+	}
+	return {
+		...commonRegionPart,
+		name: reader.nextString(27),
 	};
 }

--- a/src/packet-processors/processors/retainerInformation.ts
+++ b/src/packet-processors/processors/retainerInformation.ts
@@ -2,7 +2,7 @@ import { BufferReader } from "../../BufferReader";
 import { RetainerInformation } from "../../definitions";
 import { ConstantsList, Region } from "../../models";
 
-export function retainerInformation(reader: BufferReader, constants: ConstantsList, region: Region): RetainerInformation {
+export function retainerInformation(reader: BufferReader, constants: ConstantsList, region?: Region): RetainerInformation {
 	const commonRegionPart = {
 		unknown0: reader.nextUInt64(),
 		retainerId: reader.nextUInt64(),


### PR DESCRIPTION
The remaining packets does not seem to be used, but they were separated just in case.