### PR TITLE
Increment 'offset' in BufferReader's 'nextBuffer' method

### DIFF
--- a/src/BufferReader.ts
+++ b/src/BufferReader.ts
@@ -14,7 +14,7 @@ export class BufferReader {
 		return this.buf;
 	}
 
-	constructor(private buf: Buffer) { }
+	constructor(private buf: Buffer) {}
 
 	reset(): BufferReader {
 		this.offset = 0;

--- a/src/BufferReader.ts
+++ b/src/BufferReader.ts
@@ -14,7 +14,7 @@ export class BufferReader {
 		return this.buf;
 	}
 
-	constructor(private buf: Buffer) {}
+	constructor(private buf: Buffer) { }
 
 	reset(): BufferReader {
 		this.offset = 0;
@@ -52,6 +52,7 @@ export class BufferReader {
 	nextBuffer(length: number, asReader: true): BufferReader;
 	nextBuffer(length: number, asReader?: boolean): Buffer | BufferReader {
 		const buf = this.buf.slice(this.offset, this.offset + length);
+		this.offset += length
 		if (asReader) {
 			return new BufferReader(buf);
 		}

--- a/src/BufferReader.ts
+++ b/src/BufferReader.ts
@@ -52,7 +52,7 @@ export class BufferReader {
 	nextBuffer(length: number, asReader: true): BufferReader;
 	nextBuffer(length: number, asReader?: boolean): Buffer | BufferReader {
 		const buf = this.buf.slice(this.offset, this.offset + length);
-		this.offset += length
+		this.offset += length;
 		if (asReader) {
 			return new BufferReader(buf);
 		}


### PR DESCRIPTION
Hello:

I was trying to use ffxiv-pcap to parse some market board listing history's, but I noticed the array of listings that was getting returned had the same element repeated over and over again.  I traced the issue to BufferReaders 'nextBuffer' method, which doesn't increment the byte offset of the captured packet.

This fixes that, but I am unsure if there are any side effects for other packet types, as I'm filtering for only MarketboardListingHistory packets.

Forgive me if i am violating some sort of pull request etiquette here, I don't contribute to open source projects that much.