### PR TITLE
refactor(opcodes): load from jsdelivr only if CN region

### DIFF
--- a/src/pcap-ffxiv.ts
+++ b/src/pcap-ffxiv.ts
@@ -235,10 +235,15 @@ export class CaptureInterface extends EventEmitter {
 
 		this._options.logger({
 			type: "info",
-			message: `Loading ${file} from jsdelivr`,
+			message: `Loading ${file} from ${this._options.region === "CN" ? "jsdelivr" : "github"}`,
 		});
 
-		return downloadJson(`https://cdn.jsdelivr.net/gh/karashiiro/FFXIVOpcodes@latest/${file}`);
+		const baseUrl =
+			this._options.region === "CN"
+				? "https://cdn.jsdelivr.net/gh/karashiiro/FFXIVOpcodes@latest/"
+				: "https://raw.githubusercontent.com/karashiiro/FFXIVOpcodes/master/";
+
+		return downloadJson(`${baseUrl}${file}`);
 	}
 
 	private async _loadOpcodes() {


### PR DESCRIPTION
This is made to avoid having cache issues on patch day in global and korean regions just because the cache clear action failed because jsdelivr's API cannot be trusted at all.