### PR TITLE
fix(submarineprogressionstatus): sectors data went from 10 to 15.

### DIFF
--- a/src/packet-processors/processors/submarineProgressionStatus.ts
+++ b/src/packet-processors/processors/submarineProgressionStatus.ts
@@ -1,7 +1,7 @@
 import { BufferReader } from "../../BufferReader";
 import { SubmarineProgressionStatus } from "../../definitions";
 
-const SECTORS_DATA_LENGTH = 10;
+const SECTORS_DATA_LENGTH = 15;
 const MASK = 0x1;
 
 function getProgression(buffer: BufferReader) {


### PR DESCRIPTION
SE added more bytes for the progression so the offset of the `exploredSectors` got shifted