### PR TITLE
Add raw packet data to Message

### DIFF
--- a/src/models/GenericMessage.ts
+++ b/src/models/GenericMessage.ts
@@ -5,4 +5,5 @@ export interface GenericMessage<T = any> extends Segment {
 	type: string;
 	subType?: string;
 	parsedIpcData?: T;
+	data?: Buffer;
 }

--- a/src/pcap-ffxiv.ts
+++ b/src/pcap-ffxiv.ts
@@ -341,6 +341,7 @@ export class CaptureInterface extends EventEmitter {
 				header,
 				opcode,
 				type: typeName as any,
+				data: Buffer.from(dataReader.buffer),
 			};
 
 			if (this._options.filter(header, typeName)) {


### PR DESCRIPTION
I found myself running into the need for this while working on a bot for my venue to get analytics and announce new songs coming on from our radio. This will allow you to just use `.data` on a message returned in the callback from `CaptureInterface`

I put together a quick example with output, loosely based on my project: https://gist.github.com/LaneSage/85e564c9f22df29f29219305f49a6aa6