### PR TITLE
chore: use ffcafe cdn instead of gitee

### DIFF
--- a/src/pcap-ffxiv.ts
+++ b/src/pcap-ffxiv.ts
@@ -236,12 +236,12 @@ export class CaptureInterface extends EventEmitter {
 
 		this._options.logger({
 			type: "info",
-			message: `Loading ${file} from ${this._options.region === "CN" ? "jsdelivr" : "github"}`,
+			message: `Loading ${file} from ${this._options.region === "CN" ? "ffcafe" : "github"}`,
 		});
 
 		const baseUrl =
 			this._options.region === "CN"
-				? "https://gitee.com/mundanity/FFXIVOpcodes_Fork_Sync-with-Gitee/raw/fork/"
+				? "https://opcodes.xivcdn.com/"
 				: "https://raw.githubusercontent.com/karashiiro/FFXIVOpcodes/master/";
 
 		return downloadJson(`${baseUrl}${file}`);


### PR DESCRIPTION
This PR changes gitee services into FFCAFE hosted service for fetching opcodes.

---

We (@thewakingsands aka FFCAFE) noticed that recently there are jsdelivr connection issues in China.

As https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/issues/2262 says, there's already a Gitee-hosted repo for opcodes, but recently Gitee has added many more censorship rules about open source projects. It's very unclear to say how stable it can be, so we decided to maintain a CDN for Chinese users.

This service is hosted on the same server as CafeMaker, which is used for the CN region in TeamCraft for a while, and we'll try our best to maintain this service as well. You can touch us at any time in Discord or GitHub and it's hosted under our domain which has a Chinese ICP license so It's more trustworthy, so I think it's better to use our service rather than any public service hosted by some Chinese commercial company.

At this time, we sync with https://github.com/karashiiro/FFXIVOpcodes per 15mins.