### PR TITLE
Update market packets for 7.0

### DIFF
--- a/prebuild.js
+++ b/prebuild.js
@@ -84,6 +84,7 @@ function generateInterfaces(processors, parentInterfaceName, excludeImports) {
 function createMessageType() {
 	const { processors } = generateImportsAndProcessors("processors");
 	const actorControlProcessors = generateImportsAndProcessors("processors/actor-control").processors;
+	const desynthResultProcessors = generateImportsAndProcessors("processors/desynth-result").processors;
 	const resultDialogProcessors = generateImportsAndProcessors("processors/result-dialog").processors;
 
 	const entries = [
@@ -91,6 +92,7 @@ function createMessageType() {
 		...generateInterfaces(actorControlProcessors, "ActorControl"),
 		...generateInterfaces(actorControlProcessors, "ActorControlSelf", true),
 		...generateInterfaces(actorControlProcessors, "ActorControlTarget", true),
+		...generateInterfaces(desynthResultProcessors, "DesynthResult"),
 		...generateInterfaces(resultDialogProcessors, "ResultDialog"),
 	];
 
@@ -134,6 +136,16 @@ createProcessorsLoader(
 	[`import { ResultDialog } from "../definitions";`],
 );
 
+createProcessorsLoader(
+	"desynth-result-packet-processors",
+	"desynthResultPacketProcessors",
+	"processors/desynth-result",
+	"SuperPacketProcessor<DesynthResult>",
+	"SuperPacketProcessor",
+	[`import { DesynthResult } from "../definitions";`],
+);
+
 createMessageType();
 
 updateDllHash();
+

--- a/src/definitions/DesynthResult.ts
+++ b/src/definitions/DesynthResult.ts
@@ -1,11 +1,4 @@
-export interface DesynthResult {
-	unknown0: number;
-	unknown1: number;
-	itemId: number;
-	itemHq: boolean;
-	result: {
-		itemId: number;
-		itemHq: boolean;
-		itemQuantity: number;
-	}[];
-}
+import { SuperPacket } from "../models/SuperPacket";
+
+export interface DesynthResult extends SuperPacket {}
+

--- a/src/definitions/MarketBoardItemListing.ts
+++ b/src/definitions/MarketBoardItemListing.ts
@@ -14,7 +14,6 @@ export interface MarketBoardItemListing {
 		quantity: number;
 		itemId: number;
 		lastReviewTime: number;
-		containerId: number;
 		slot: number;
 		durability: number;
 		spiritbond: number;
@@ -32,8 +31,14 @@ export interface MarketBoardItemListing {
 		materiaCount: number;
 		onMannequin: boolean;
 		city: number;
+		/** @deprecated Use primaryDyeId and secondaryDyeId. */
 		dyeId: number;
+		primaryDyeId: number;
+		secondaryDyeId: number;
 		padding3: number;
-		padding4: number;
 	}[];
+	listingIndexEnd: number;
+	listingIndexStart: number;
+	requestId: number;
 }
+

--- a/src/definitions/MarketBoardItemListingCount.ts
+++ b/src/definitions/MarketBoardItemListingCount.ts
@@ -1,7 +1,4 @@
 export interface MarketBoardItemListingCount {
-	itemCatalogId: number;
-	unknown1: number;
-	requestId: number;
-	unknown2: number;
+	status: number;
 	quantity: number;
 }

--- a/src/definitions/MarketBoardItemListingHistory.ts
+++ b/src/definitions/MarketBoardItemListingHistory.ts
@@ -1,14 +1,12 @@
 export interface MarketBoardItemListingHistory {
 	itemCatalogId: number;
-	itemCatalogId2: number;
 	listings: {
 		salePrice: number;
 		purchaseTime: number;
 		quantity: number;
 		isHq: boolean;
-		padding: number;
 		onMannequin: boolean;
 		buyerName: string;
-		itemCatalogId: number;
+		padding: number;
 	}[];
 }

--- a/src/definitions/desynth-result/ItemDesynthResult.ts
+++ b/src/definitions/desynth-result/ItemDesynthResult.ts
@@ -1,0 +1,11 @@
+export interface ItemDesynthResult {
+	unknown1: number;
+	itemId: number;
+	itemHq: boolean;
+	result: {
+		itemId: number;
+		itemHq: boolean;
+		itemQuantity: number;
+	}[];
+}
+

--- a/src/definitions/desynth-result/MarketTaxRates.ts
+++ b/src/definitions/desynth-result/MarketTaxRates.ts
@@ -7,4 +7,6 @@ export interface MarketTaxRates {
 	kugane: number;
 	crystarium: number;
 	oldSharlayan: number;
+	tuliyollal: number;
+	validUntil: number;
 }

--- a/src/definitions/index.ts
+++ b/src/definitions/index.ts
@@ -95,4 +95,5 @@ export * from "./actor-control/SetMountSpeed";
 export * from "./actor-control/StatusEffectLose";
 export * from "./actor-control/ToggleWeapon";
 export * from "./actor-control/UpdateRestedExp";
-export * from "./result-dialog/MarketTaxRates";
+export * from "./desynth-result/ItemDesynthResult";
+export * from "./desynth-result/MarketTaxRates";

--- a/src/models/DesynthResultType.ts
+++ b/src/models/DesynthResultType.ts
@@ -1,0 +1,5 @@
+export enum DesynthResultType {
+	// ItemDesynthResult?
+	MarketTaxRates = 0xb0009,
+}
+

--- a/src/models/Message.ts
+++ b/src/models/Message.ts
@@ -87,6 +87,7 @@ import { SetMountSpeed } from "../definitions";
 import { StatusEffectLose } from "../definitions";
 import { ToggleWeapon } from "../definitions";
 import { UpdateRestedExp } from "../definitions";
+import { ItemDesynthResult } from "../definitions";
 import { MarketTaxRates } from "../definitions";
 import { ReductionResult } from "../definitions";
 
@@ -546,8 +547,13 @@ export interface ActorControlTargetUpdateRestedExpMessage extends GenericMessage
 	subType: "updateRestedExp";
 }
 
-export interface ResultDialogMarketTaxRatesMessage extends GenericMessage<MarketTaxRates> {
-	type: "resultDialog";
+export interface DesynthResultItemDesynthResultMessage extends GenericMessage<ItemDesynthResult> {
+	type: "desynthResult";
+	subType: "itemDesynthResult";
+}
+
+export interface DesynthResultMarketTaxRatesMessage extends GenericMessage<MarketTaxRates> {
+	type: "desynthResult";
 	subType: "marketTaxRates";
 }
 
@@ -663,5 +669,6 @@ export type Message =
 	| ActorControlTargetStatusEffectLoseMessage
 	| ActorControlTargetToggleWeaponMessage
 	| ActorControlTargetUpdateRestedExpMessage
-	| ResultDialogMarketTaxRatesMessage
+	| DesynthResultItemDesynthResultMessage
+	| DesynthResultMarketTaxRatesMessage
 	| ResultDialogReductionResultMessage;

--- a/src/models/ResultDialogType.ts
+++ b/src/models/ResultDialogType.ts
@@ -1,4 +1,3 @@
 export enum ResultDialogType {
-	MarketTaxRates = 0xb0009,
 	ReductionResult = 0x390002,
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -4,6 +4,7 @@
 
 export * from "./ActorControlType";
 export * from "./ConstantsList";
+export * from "./DesynthResultType";
 export * from "./DeucalionPacket";
 export * from "./DeucalionPayload";
 export * from "./ErrorCodes";

--- a/src/packet-processors/desynth-result-packet-processors.ts
+++ b/src/packet-processors/desynth-result-packet-processors.ts
@@ -1,0 +1,15 @@
+import { SuperPacketProcessor } from "../models";
+import { itemDesynthResult } from "./processors/desynth-result/itemDesynthResult";
+import { marketTaxRates } from "./processors/desynth-result/marketTaxRates";
+import { DesynthResult } from "../definitions";
+
+/**
+* THIS IS A GENERATED FILE, DO NOT EDIT IT BY HAND.
+*
+* To update it, restart the build process.
+*/
+
+export const desynthResultPacketProcessors: Record<string, SuperPacketProcessor<DesynthResult>> = { 
+	itemDesynthResult,
+	marketTaxRates, 
+};

--- a/src/packet-processors/processors/desynth-result/itemDesynthResult.ts
+++ b/src/packet-processors/processors/desynth-result/itemDesynthResult.ts
@@ -1,0 +1,25 @@
+import { BufferReader } from "../../../BufferReader";
+import { ItemDesynthResult } from "../../../definitions/desynth-result/ItemDesynthResult";
+import { DesynthResult } from "../../../definitions/DesynthResult";
+
+export function itemDesynthResult(packet: DesynthResult, reader: BufferReader): ItemDesynthResult {
+	const unknown01 = reader.nextUInt32();
+	const itemResult = reader.nextUInt32();
+	return {
+		...packet,
+		unknown1: unknown01,
+		itemId: itemResult % 1000000,
+		itemHq: itemResult > 1000000,
+		result: Array(3)
+			.fill(null)
+			.map(() => {
+				const itemResult = reader.nextUInt32();
+				return {
+					itemId: itemResult % 1000000,
+					itemHq: itemResult > 1000000,
+					itemQuantity: reader.nextUInt32(),
+				};
+			}),
+	};
+}
+

--- a/src/packet-processors/processors/desynth-result/marketTaxRates.ts
+++ b/src/packet-processors/processors/desynth-result/marketTaxRates.ts
@@ -1,7 +1,7 @@
-import { MarketTaxRates, ResultDialog } from "../../../definitions";
+import { DesynthResult, MarketTaxRates } from "../../../definitions";
 import { BufferReader } from "../../../BufferReader";
 
-export function marketTaxRates(packet: ResultDialog, reader: BufferReader): MarketTaxRates {
+export function marketTaxRates(packet: DesynthResult, reader: BufferReader): MarketTaxRates {
 	return {
 		...packet,
 		limsaLominsa: reader.skip(0x08).nextUInt32(),
@@ -11,5 +11,7 @@ export function marketTaxRates(packet: ResultDialog, reader: BufferReader): Mark
 		kugane: reader.nextUInt32(),
 		crystarium: reader.nextUInt32(),
 		oldSharlayan: reader.nextUInt32(),
+		tuliyollal: reader.nextUInt32(),
+		validUntil: reader.nextUInt32(),
 	};
 }

--- a/src/packet-processors/processors/desynthResult.ts
+++ b/src/packet-processors/processors/desynthResult.ts
@@ -1,24 +1,9 @@
 import { BufferReader } from "../../BufferReader";
-import { DesynthResult } from "../../definitions";
+import { DesynthResult } from "../../definitions/DesynthResult";
 
 export function desynthResult(reader: BufferReader): DesynthResult {
-	const unknown00 = reader.nextUInt32();
-	const unknown01 = reader.nextUInt32();
-	const itemResult = reader.nextUInt32();
 	return {
-		unknown0: unknown00,
-		unknown1: unknown01,
-		itemId: itemResult % 1000000,
-		itemHq: itemResult > 1000000,
-		result: Array(3)
-			.fill(null)
-			.map(() => {
-				const itemResult = reader.nextUInt32();
-				return {
-					itemId: itemResult % 1000000,
-					itemHq: itemResult > 1000000,
-					itemQuantity: reader.nextUInt32(),
-				};
-			}),
+		category: reader.nextUInt32(),
 	};
 }
+

--- a/src/packet-processors/processors/marketBoardItemListing.ts
+++ b/src/packet-processors/processors/marketBoardItemListing.ts
@@ -15,8 +15,8 @@ export function marketBoardItemListing(reader: BufferReader): MarketBoardItemLis
 					totalTax: reader.nextUInt32(),
 					quantity: reader.nextUInt32(),
 					itemId: reader.nextUInt32(),
-					lastReviewTime: reader.nextUInt32(),
-					containerId: reader.nextUInt16(),
+					// Removed in 7.0; using placeholder value for backwards-compatibility
+					lastReviewTime: 0,
 					slot: reader.nextUInt16(),
 					durability: reader.nextUInt16(),
 					spiritbond: reader.nextUInt16(),
@@ -32,16 +32,26 @@ export function marketBoardItemListing(reader: BufferReader): MarketBoardItemLis
 					padding1: reader.nextUInt16(),
 					padding2: reader.nextUInt32(),
 					retainerName: reader.nextString(0x20),
+					// Empty as of 7.0
 					playerName: reader.nextString(0x20),
 					hq: reader.nextUInt8() === 1,
 					materiaCount: reader.nextUInt8(),
 					onMannequin: reader.nextUInt8() === 1,
 					city: reader.nextUInt8(),
-					dyeId: reader.nextUInt16(),
-					padding3: reader.nextUInt16(),
-					padding4: reader.nextUInt32(),
+					primaryDyeId: reader.nextUInt8(),
+					secondaryDyeId: reader.nextUInt8(),
+					padding3: reader.nextUInt32(),
 				};
 			})
+			.map((listing) => ({
+				...listing,
+				// Repack the data for backwards-compatibility
+				dyeId: (listing.primaryDyeId << 8) | listing.secondaryDyeId,
+			}))
 			.filter((listing) => listing.pricePerUnit > 0),
+		listingIndexEnd: reader.nextUInt8(),
+		listingIndexStart: reader.nextUInt8(),
+		requestId: reader.nextUInt16(),
 	};
 }
+

--- a/src/packet-processors/processors/marketBoardItemListingCount.ts
+++ b/src/packet-processors/processors/marketBoardItemListingCount.ts
@@ -3,10 +3,8 @@ import { BufferReader } from "../../BufferReader";
 
 export function marketBoardItemListingCount(reader: BufferReader): MarketBoardItemListingCount {
 	return {
-		itemCatalogId: reader.nextUInt32(),
-		unknown1: reader.nextUInt32(),
-		requestId: reader.nextUInt16(),
-		unknown2: reader.nextUInt8(),
-		quantity: reader.nextUInt16(),
+		// Known values: default=0; rate limited=0x70000003
+		status: reader.nextUInt32(),
+		quantity: reader.nextUInt32(),
 	};
 }

--- a/src/packet-processors/processors/marketBoardItemListingHistory.ts
+++ b/src/packet-processors/processors/marketBoardItemListingHistory.ts
@@ -4,21 +4,20 @@ import { BufferReader } from "../../BufferReader";
 export function marketBoardItemListingHistory(reader: BufferReader): MarketBoardItemListingHistory {
 	return {
 		itemCatalogId: reader.nextUInt32(),
-		itemCatalogId2: reader.nextUInt32(),
 		listings: Array(20)
 			.fill(null)
 			.map(() => {
-				const chunk = reader.nextBuffer(52, true);
+				const chunk = reader.nextBuffer(48, true);
 				return {
 					salePrice: chunk.nextUInt32(),
 					purchaseTime: chunk.nextUInt32(),
 					quantity: chunk.nextUInt32(),
 					isHq: Boolean(chunk.nextUInt8()),
-					padding: chunk.nextUInt8(),
 					onMannequin: Boolean(chunk.nextUInt8()),
 					buyerName: chunk.nextString(0x20),
-					itemCatalogId: chunk.nextUInt32(),
+					padding: chunk.nextUInt16(),
 				};
-			}),
+			})
+			.filter((sale) => sale.salePrice !== 0),
 	};
 }

--- a/src/packet-processors/result-dialog-packet-processors.ts
+++ b/src/packet-processors/result-dialog-packet-processors.ts
@@ -1,5 +1,4 @@
 import { SuperPacketProcessor } from "../models";
-import { marketTaxRates } from "./processors/result-dialog/marketTaxRates";
 import { reductionResult } from "./processors/result-dialog/reductionResult";
 import { ResultDialog } from "../definitions";
 
@@ -10,6 +9,5 @@ import { ResultDialog } from "../definitions";
 */
 
 export const resultDialogPacketProcessors: Record<string, SuperPacketProcessor<ResultDialog>> = { 
-	marketTaxRates,
 	reductionResult, 
 };

--- a/src/pcap-ffxiv.ts
+++ b/src/pcap-ffxiv.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "events";
 import {
 	ActorControlType,
 	ConstantsList,
+	DesynthResultType,
 	DeucalionPacket,
 	ErrorCodes,
 	Message,
@@ -18,6 +19,7 @@ import { BufferReader } from "./BufferReader";
 import { join } from "path";
 import { existsSync, readFileSync } from "fs";
 import { actorControlPacketProcessors } from "./packet-processors/actor-control-packet-processors";
+import { desynthResultPacketProcessors } from "./packet-processors/desynth-result-packet-processors";
 import { resultDialogPacketProcessors } from "./packet-processors/result-dialog-packet-processors";
 import { CaptureInterfaceOptions } from "./capture-interface-options";
 import { Deucalion } from "./Deucalion";
@@ -72,6 +74,7 @@ export class CaptureInterface extends EventEmitter {
 			actorControl: actorControlPacketProcessors,
 			actorControlSelf: actorControlPacketProcessors,
 			actorControlTarget: actorControlPacketProcessors,
+			desynthResult: desynthResultPacketProcessors,
 			resultDialog: resultDialogPacketProcessors,
 		};
 
@@ -307,6 +310,9 @@ export class CaptureInterface extends EventEmitter {
 			case "actorControlSelf":
 			case "actorControlTarget":
 				subTypesEnum = ActorControlType;
+				break;
+			case "desynthResult":
+				subTypesEnum = DesynthResultType;
 				break;
 			case "resultDialog":
 				subTypesEnum = ResultDialogType;


### PR DESCRIPTION
- Update packet layouts
- Move MarketTaxRates under DesynthResult (not sure which category the old desynth result is under now)

**Notes**
- `dyeId` is actually two `uint8` values for the primary and secondary dyes - Universalis is still consuming them as one `uint16` for the time being
- `containerId` on listings has been removed
- `lastReviewTime` on listings has been removed, but I'm filling it with a 0 for the time being as that would have represented a listing that has just been posted
- The count packet has had most of its information removed, and has a new status field which seems to just communicate when the client is being rate-limited

References:
- https://github.com/goaaats/universalis_act_plugin/commit/cfa06bb7fcaa3a83243555f5b616b6515df93559
- https://github.com/goatcorp/Dalamud/pull/1868/files