### PR TITLE
fix(freecompanyDialog): fix fcTag for Korean

### DIFF
--- a/src/packet-processors/processors/freeCompanyDialog.ts
+++ b/src/packet-processors/processors/freeCompanyDialog.ts
@@ -15,7 +15,7 @@ export function freeCompanyDialog(buffer: BufferReader): FreeCompanyDialog {
 		fcRank: buffer.nextUInt8(),
 		fcName: buffer.nextString(20),
 		padding1: buffer.nextUInt16(),
-		fcTag: buffer.nextString(5),
+		fcTag: buffer.nextString(6),
 		padding2: buffer.nextUInt16(),
 	};
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a18d28e4-ff65-418a-9c06-9a6f3380c355)

The last character is broken for Korean