### PR TITLE
fix: fix Korean text corruption at maximum character length

### DIFF
--- a/src/packet-processors/processors/freeCompanyDialog.ts
+++ b/src/packet-processors/processors/freeCompanyDialog.ts
@@ -13,9 +13,9 @@ export function freeCompanyDialog(buffer: BufferReader): FreeCompanyDialog {
 		unknown6: buffer.nextUInt32(),
 		unknown7: buffer.nextUInt8(),
 		fcRank: buffer.nextUInt8(),
-		fcName: buffer.nextString(20),
-		padding1: buffer.nextUInt16(),
+		fcName: buffer.nextString(21),
+		padding1: buffer.nextUInt8(),
 		fcTag: buffer.nextString(6),
-		padding2: buffer.nextUInt16(),
+		padding2: buffer.nextUInt8(),
 	};
 }

--- a/src/packet-processors/processors/retainerInformation.ts
+++ b/src/packet-processors/processors/retainerInformation.ts
@@ -1,8 +1,15 @@
 import { BufferReader } from "../../BufferReader";
 import { RetainerInformation } from "../../definitions";
-import { ConstantsList } from "../../models";
+import { ConstantsList, Region } from "../../models";
 
-export function retainerInformation(reader: BufferReader, constants?: ConstantsList): RetainerInformation {
+export function retainerInformation(
+	reader: BufferReader,
+	constants?: ConstantsList,
+	region?: Region,
+): RetainerInformation {
+	// Global: 20 characters.
+	// Korean: 9 characters (each character is 3 bytes).
+	const nameLength = region != "KR" ? 20 : 27;
 	return {
 		unknown0: reader.nextUInt64(),
 		retainerId: reader.nextUInt64(),
@@ -18,6 +25,6 @@ export function retainerInformation(reader: BufferReader, constants?: ConstantsL
 		ventureId: reader.nextUInt32(),
 		ventureComplete: reader.nextUInt32(),
 		unknown14: reader.nextUInt8(),
-		name: reader.skip(4).nextString(20),
+		name: reader.skip(4).nextString(nameLength),
 	};
 }


### PR DESCRIPTION
# freeCompanyDialog
Global: 20 characters for name, 5 characters for Tag
Korean: 7 characters for name, 2 characters for Tag
- Increase by 1 byte for `fcName` and adjust the padding.
- Re-adjust `padding2` since it wasn't modified last time.

# retainerInformation
Global: 20 characters for name
Korean: 9 characters for name
- Adjust the character length for Retainer name based on the region.

## Log
![image](https://github.com/user-attachments/assets/6f9654d5-bc9b-46b7-8b1a-0b49af932567)
[v705.250305.RetainerInformation.xml.txt](https://github.com/user-attachments/files/19083666/v705.250305.RetainerInformation.xml.txt)


Here is the log included `freeCompanyDialog` and `retainerInformation`
